### PR TITLE
Bug Fixes/Changes for Discord Chat Integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.jvmargs=-Xmx2G
 
 # BTA
-bta_version=1.7.7.0_02
+bta_version=7.1-pre1
 
 # Loader
 loader_version=0.14.19-babric.1-bta
 
 # HalpLibe
-halplibe_version=2.1.5
+halplibe_version=3.0.0
 
 # Mod
 mod_version=1.0.0

--- a/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_MinecraftServer.java
+++ b/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_MinecraftServer.java
@@ -13,7 +13,9 @@ public class Mixin_MinecraftServer {
             method = "initiateShutdown",
             at = @At("RETURN")
     )
+
     void sendStopMessage(CallbackInfo ci) {
-        DiscordChatRelay.sendMessageAsBot("**Server stopped.**");
+        DiscordChatRelay.sendMessageAsBot("**Server Stopped**");
     }
+
 }

--- a/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_NetLoginHandler.java
+++ b/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_NetLoginHandler.java
@@ -22,8 +22,8 @@ public class Mixin_NetLoginHandler {
             ),
             locals = LocalCapture.CAPTURE_FAILHARD
     )
-    void sendLoginMessage(Packet1Login packet1login, CallbackInfo ci, EntityPlayerMP player) {
-        String username = player.getDisplayName().replaceFirst("^§0", "");
+    void sendJoinMessage(Packet1Login packet1login, CallbackInfo ci, EntityPlayerMP player) {
+        String username = player.username;
         DiscordChatRelay.sendJoinLeaveMessage(username, true);
     }
 }

--- a/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_NetServerHandler.java
+++ b/src/main/java/de/olivermakesco/bta_utils/mixin/server/Mixin_NetServerHandler.java
@@ -30,7 +30,7 @@ public class Mixin_NetServerHandler {
             return message;
         }
 
-        String username = playerEntity.getDisplayName().replaceFirst("^§0", "");
+        String username = playerEntity.username;
 
         DiscordChatRelay.sendToDiscord(username, message);
 
@@ -41,8 +41,8 @@ public class Mixin_NetServerHandler {
             method = "handleErrorMessage",
             at = @At("HEAD")
     )
-    void sendLogoutMessage(String s, Object[] aobj, CallbackInfo ci) {
-        String username = playerEntity.getDisplayName().replaceFirst("^§0", "");
+    void sendLeaveMessage(String s, Object[] aobj, CallbackInfo ci) {
+        String username = playerEntity.username;
         DiscordChatRelay.sendJoinLeaveMessage(username, false);
     }
 }

--- a/src/main/java/de/olivermakesco/bta_utils/server/DiscordChatRelay.java
+++ b/src/main/java/de/olivermakesco/bta_utils/server/DiscordChatRelay.java
@@ -16,7 +16,7 @@ public class DiscordChatRelay {
         BtaUtilsMod.info(message);
         String[] lines = message.split("\n");
         for (String chatMessage : lines) {
-            server.configManager.sendEncryptedChatToAllPlayers(
+            server.playerList.sendEncryptedChatToAllPlayers(
                     chatMessage
             );
         }

--- a/src/main/java/de/olivermakesco/bta_utils/server/DiscordChatRelay.java
+++ b/src/main/java/de/olivermakesco/bta_utils/server/DiscordChatRelay.java
@@ -7,6 +7,7 @@ import de.olivermakesco.bta_utils.config.BtaUtilsConfig;
 import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel;
 import net.minecraft.core.net.command.TextFormatting;
 import net.minecraft.server.MinecraftServer;
+import org.jetbrains.annotations.Nullable;
 
 public class DiscordChatRelay {
     public static void sendToMinecraft(String author, String message) {
@@ -33,7 +34,7 @@ public class DiscordChatRelay {
 
         WebhookMessageBuilder builder = new WebhookMessageBuilder();
         builder.setUsername(author);
-        builder.setAvatarUrl("https://visage.surgeplay.com/face/256/"+author);
+        builder.setAvatarUrl("https://visage.surgeplay.com/face/216/" + author);
         builder.setContent(message);
         webhook.send(builder.build());
     }

--- a/src/main/java/de/olivermakesco/bta_utils/server/DiscordClient.java
+++ b/src/main/java/de/olivermakesco/bta_utils/server/DiscordClient.java
@@ -110,24 +110,17 @@ public class DiscordClient {
                     return;
                 }
 
-                Member member = message.getMember();
                 User user = message.getAuthor();
 
-                String username = getDisplayName(user, member);
+                String username = getDisplayName(user);
                 String content = ChatEmotes.process(message.getMessage().getContentStripped());
 
                 DiscordChatRelay.sendToMinecraft(username, content);
             }
         }
 
-        public static String getDisplayName(User user, @Nullable Member member) {
-            String username = pick(user.getGlobalName(), user.getName());
-
-            if (member == null) {
-                return username;
-            }
-
-            return pick(member.getNickname(), username);
+        public static String getDisplayName(User user) {
+            return user.getName();
         }
 
         public static String pick(@Nullable String first, @Nullable String second) {


### PR DESCRIPTION
Swaps out player.getDisplayName() for the player.username field to avoid some problems with the nicknaming and coloring system in BTA. Now all Bot PFPs work and the name displayed is the player's true MC Username